### PR TITLE
compilation fixed on OS X

### DIFF
--- a/src/globals.h
+++ b/src/globals.h
@@ -1,5 +1,5 @@
 #ifdef __APPLE__
-#include <ncursesw/cursesw.h>
+#include <curses.h>
 #else
 #include <cursesw.h>
 #endif

--- a/src/helperFns.h
+++ b/src/helperFns.h
@@ -1,5 +1,5 @@
 #ifdef __APPLE__
-#include <ncursesw/cursesw.h>
+#include <curses.h>
 #else
 #include <cursesw.h>
 #endif


### PR DESCRIPTION
Hello again,
The build fails on OS X without this patch.

In fact `curses` is already provided by OS X, you don’t need to install it via Homebrew.