### PR TITLE
Full Makefile added, custom maps location support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,5 @@ pacvim
 *~
 *.swp
 *.swo
+.deps
+*.o

--- a/Makefile
+++ b/Makefile
@@ -1,2 +1,45 @@
-all: 
-	g++ src/game.cpp -pthread -std=c++11 -lncurses src/globals.cpp src/helperFns.cpp src/avatar.cpp src/ghost1.cpp -o pacvim
+SRCS   = $(wildcard src/*.cpp)
+OBJS   = $(SRCS:.cpp=.o)
+
+PREFIX = /usr/local
+BINDIR = $(PREFIX)/bin
+SHARE  = $(PREFIX)/share
+MAPDIR = $(SHARE)/pacvim-maps
+
+CXX    = g++
+CFLAGS = -std=c++11 -DMAPS_LOCATION='"$(MAPDIR)"'
+LFLAGS = -lncurses
+
+TARGET = pacvim
+MAPS   = maps
+DEPS   = .deps
+
+ifneq ($(shell uname -s 2>/dev/null || echo nop),Darwin)
+# OS has POSIX threads in libc
+CFLAGS += -pthread
+endif
+
+all: $(TARGET)
+
+$(TARGET): $(OBJS)
+	$(CXX) $(CFLAGS) $^ $(LFLAGS) -o $@
+
+%.o: %.cpp
+	$(CXX) $(CFLAGS) -c -o $@ $<
+
+$(DEPS):
+	$(CXX) -M $(SRCS) >| $@
+
+clean:
+	$(RM) $(OBJS) $(DEPS)
+
+install: $(TARGET)
+	install -d $(BINDIR) $(SHARE)
+	install -m 755 $(TARGET) $(BINDIR)/
+	cp -r $(MAPS) $(MAPDIR)
+
+uninstall:
+	$(RM) $(BINDIR)/$(TARGET)
+	$(RM) -r $(MAPDIR)
+
+-include $(DEPS)

--- a/src/game.cpp
+++ b/src/game.cpp
@@ -549,7 +549,7 @@ int main(int argc, char** argv)
 	}
 
 	while(LIVES >= 0) {
-		string mapName = "maps/map";
+		string mapName = MAPS_LOCATION "/map";
 		
 		// convert CURRENT_LEVEL to string, and load
 		std::stringstream ss;

--- a/src/globals.h
+++ b/src/globals.h
@@ -32,3 +32,6 @@ extern int WIDTH;
 extern std::mutex mtx;
 #endif
 
+#ifndef MAPS_LOCATION
+#define MAPS_LOCATION "maps"
+#endif


### PR DESCRIPTION
Hello again,
This PR adds a full Makefile which features separate compilation tasks, and `install`/`uninstall` targets, with support for a custom maps location.

It allows you to type:

    make
    [sudo] make install

to install the game and have it in your PATH (so you can just type `pacvim` and it launches it), as well as `make uninstall` to uninstall it.

The downside is that the maps directory location is fixed when the binary is compiled (which was already the case), which means you have to recompile it when you install it somewhere else.
By default, the maps location is at `/usr/local/share/pacvim-maps/`. You can revert to the original behavior by running `make MAPDIR=maps`.

Feel free to comment on the code if you have any question.

The initial motivation for this PR was that with Homebrew, binaries are installed in a `bin` directory and other files in another directory, which means we have to patch the code before installing.