### PR TITLE
Update Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,45 +1,28 @@
-SRCS   = $(wildcard src/*.cpp)
-OBJS   = $(SRCS:.cpp=.o)
-
-PREFIX = /usr/local
-BINDIR = $(PREFIX)/bin
-SHARE  = $(PREFIX)/share
-MAPDIR = $(SHARE)/pacvim-maps
-
-CXX    = g++
-CFLAGS = -std=c++11 -DMAPS_LOCATION='"$(MAPDIR)"'
-LFLAGS = -lncurses
-
-TARGET = pacvim
-MAPS   = maps
-DEPS   = .deps
+TARGET     =  pacvim
+PREFIX    ?=  /usr/local
+BINDIR     =  $(PREFIX)/bin
+MAPDIR     =  $(PREFIX)/share/pacvim-maps
+OBJS      :=  $(patsubst %.cpp,%.o,$(wildcard src/*.cpp))
+MAPS      :=  $(wildcard maps/*)
+CXX       ?=  g++
+CXXFLAGS  +=  -std=c++11 -DMAPS_LOCATION='"$(MAPDIR)"'
+LDLIBS    +=  -lncurses -lpthread
 
 ifneq ($(shell uname -s 2>/dev/null || echo nop),Darwin)
 # OS has POSIX threads in libc
-CFLAGS += -pthread
+CXXFLAGS += -pthread
 endif
 
-all: $(TARGET)
-
 $(TARGET): $(OBJS)
-	$(CXX) $(CFLAGS) $^ $(LFLAGS) -o $@
-
-%.o: %.cpp
-	$(CXX) $(CFLAGS) -c -o $@ $<
-
-$(DEPS):
-	$(CXX) -M $(SRCS) >| $@
-
-clean:
-	$(RM) $(OBJS) $(DEPS)
+	$(CXX) $(LDFLAGS) $(LDLIBS) $^ -o $@
 
 install: $(TARGET)
-	install -d $(BINDIR) $(SHARE)
-	install -m 755 $(TARGET) $(BINDIR)/
-	cp -r $(MAPS) $(MAPDIR)
+	install -Dm755 $(TARGET) $(DESTDIR)$(BINDIR)/$(TARGET)
+	install -d $(DESTDIR)$(MAPDIR)
+	install -t $(DESTDIR)$(MAPDIR) $(MAPS)
 
 uninstall:
-	$(RM) $(BINDIR)/$(TARGET)
-	$(RM) -r $(MAPDIR)
+	$(RM) $(DESTDIR)$(BINDIR)/$(TARGET)
+	$(RM) -r $(DESTDIR)$(MAPDIR)
 
--include $(DEPS)
+.PHONY: install uninstall

--- a/Makefile
+++ b/Makefile
@@ -14,7 +14,7 @@ CXXFLAGS += -pthread
 endif
 
 $(TARGET): $(OBJS)
-	$(CXX) $(CXXFLAGS) $(LDFLAGS) $(LDLIBS) $^ -o $@
+	$(CXX) $(CXXFLAGS) $(LDFLAGS) $^ -o $@ $(LDLIBS)
 
 install: $(TARGET)
 	install -Dm755 $(TARGET) $(DESTDIR)$(BINDIR)/$(TARGET)
@@ -25,4 +25,7 @@ uninstall:
 	$(RM) $(DESTDIR)$(BINDIR)/$(TARGET)
 	$(RM) -r $(DESTDIR)$(MAPDIR)
 
-.PHONY: install uninstall
+clean:
+	$(RM) $(wildcard src/*.o) $(TARGET)
+
+.PHONY: install uninstall clean

--- a/Makefile
+++ b/Makefile
@@ -14,7 +14,7 @@ CXXFLAGS += -pthread
 endif
 
 $(TARGET): $(OBJS)
-	$(CXX) $(LDFLAGS) $(LDLIBS) $^ -o $@
+	$(CXX) $(CXXFLAGS) $(LDFLAGS) $(LDLIBS) $^ -o $@
 
 install: $(TARGET)
 	install -Dm755 $(TARGET) $(DESTDIR)$(BINDIR)/$(TARGET)


### PR DESCRIPTION
This commit increases Makefile overall coherency by simplifying the file's general flow while also eliminating some of the extraneous bits. One notable issue fixed here is that CXXFLAGS will now be used in place of CFLAGS. Second, any flags issued by the user on the command-line are now incorporated in the make/build process whereas before, these were being disregarded. Finally, there was a problem that arose when forcing the addition of "-Wall" to the build command so as to increase feedback verbosity. Doing this would, in some environments, prevent the build from linking a final executable file and the process would exit-with-error, while complaining of a missing library.

This update to Makefile was contributed by a coder (not myself) who stated in a forum discussion that they do not wish attribution for their work here. Thank you, kind coder.