### PR TITLE
Add Darwin/OSX-compatible install target to Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -17,9 +17,9 @@ $(TARGET): $(OBJS)
 	$(CXX) $(CXXFLAGS) $(LDFLAGS) $^ -o $@ $(LDLIBS)
 
 install: $(TARGET)
-	install -Dm755 $(TARGET) $(DESTDIR)$(BINDIR)/$(TARGET)
+	install $(TARGET) $(DESTDIR)$(BINDIR)/$(TARGET)
 	install -d $(DESTDIR)$(MAPDIR)
-	install -t $(DESTDIR)$(MAPDIR) $(MAPS)
+	install  $(MAPS) $(DESTDIR)$(MAPDIR)
 
 uninstall:
 	$(RM) $(DESTDIR)$(BINDIR)/$(TARGET)

--- a/Makefile
+++ b/Makefile
@@ -16,6 +16,11 @@ endif
 $(TARGET): $(OBJS)
 	$(CXX) $(CXXFLAGS) $(LDFLAGS) $^ -o $@ $(LDLIBS)
 
+install: $(TARGET)
+	install -Dm755 $(TARGET) $(DESTDIR)$(BINDIR)/$(TARGET)
+	install -d $(DESTDIR)$(MAPDIR)
+	install -t $(DESTDIR)$(MAPDIR) $(MAPS)
+
 install-darwin: $(TARGET)
 	install $(TARGET) $(DESTDIR)$(BINDIR)/$(TARGET)
 	install -d $(DESTDIR)$(MAPDIR)

--- a/Makefile
+++ b/Makefile
@@ -16,7 +16,7 @@ endif
 $(TARGET): $(OBJS)
 	$(CXX) $(CXXFLAGS) $(LDFLAGS) $^ -o $@ $(LDLIBS)
 
-install: $(TARGET)
+install-darwin: $(TARGET)
 	install $(TARGET) $(DESTDIR)$(BINDIR)/$(TARGET)
 	install -d $(DESTDIR)$(MAPDIR)
 	install  $(MAPS) $(DESTDIR)$(MAPDIR)
@@ -28,4 +28,4 @@ uninstall:
 clean:
 	$(RM) $(wildcard src/*.o) $(TARGET)
 
-.PHONY: install uninstall clean
+.PHONY: install install-darwin uninstall clean

--- a/README.md
+++ b/README.md
@@ -35,9 +35,15 @@ Download and build the game with:
 ```
 2. git clone https://github.com/jmoon018/PacVim.git
 3. cd PacVim
+```
+### Linux install
+```
 4. [sudo] make install
 ```
-
+### MacOS install
+```
+4. [sudo] make install-darwin
+```
 ## Using Docker
 
 If you have docker installed already, you can just:


### PR DESCRIPTION
BSD install flags are different than GNU's install utility. The added `install-darwin` target uses the correct `BSD install` command flags