### PR TITLE
pacvim: always use "%s"-style format for printf()-style functions

### DIFF
--- a/src/game.cpp
+++ b/src/game.cpp
@@ -234,7 +234,7 @@ void levelMessage() {
 	string msg = ss.str();
 
 	// print + pause
-	printw(msg.c_str());
+	printw("%s", msg.c_str());
 	refresh();
 	usleep(1500000);
 

--- a/src/helperFns.cpp
+++ b/src/helperFns.cpp
@@ -100,14 +100,14 @@ void printAtBottomChar(char msg) {
 	//mtx.lock();
 	std::string x;
 	x += msg;
-	mvprintw(TOP+5, 0, (x).c_str());
+	mvprintw(TOP+5, 0, "%s", (x).c_str());
 	//mtx.unlock();
 }
 void printAtBottom(std::string msg) {
 	//mtx.lock();
 	int x, y;
 	getyx(stdscr, y, x);
-	mvprintw(TOP+1, 1, msg.c_str());
+	mvprintw(TOP+1, 1, "%s", msg.c_str());
 	mvinch(y,x);
 	move(y,x);
 


### PR DESCRIPTION
`ncuses-6.3` added printf-style function attributes and now makes
it easier to catch cases when user input is used in palce of format
string when built with CFLAGS=-Werror=format-security:

    src/helperFns.cpp:103:17:
      error: format not a string literal and no format arguments [-Werror=format-security]
      103 |         mvprintw(TOP+5, 0, (x).c_str());
          |         ~~~~~~~~^~~~~~~~~~~~~~~~~~~~~~~

Let's wrap all the missing places with "%s" format.