### PR TITLE
fix missing dependecies in Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -5,7 +5,7 @@ MAPDIR     =  $(PREFIX)/share/pacvim-maps
 OBJS      :=  $(patsubst %.cpp,%.o,$(wildcard src/*.cpp))
 MAPS      :=  $(wildcard maps/*)
 CXX       ?=  g++
-CXXFLAGS  +=  -std=c++11 -DMAPS_LOCATION='"$(MAPDIR)"'
+CXXFLAGS  +=  -std=c++11 -DMAPS_LOCATION=\'"$(MAPDIR)"\'
 LDLIBS    +=  -lncurses -lpthread
 
 ifneq ($(shell uname -s 2>/dev/null || echo nop),Darwin)
@@ -13,8 +13,14 @@ ifneq ($(shell uname -s 2>/dev/null || echo nop),Darwin)
 CXXFLAGS += -pthread
 endif
 
+-include $(OBJS:.o=.d)
+
 $(TARGET): $(OBJS)
 	$(CXX) $(CXXFLAGS) $(LDFLAGS) $^ -o $@ $(LDLIBS)
+
+# Generate dependency files with correct target names
+%.o: %.cpp
+	$(CXX) $(CXXFLAGS) -MMD -MP -MT $@ -c $< -o $@
 
 install: $(TARGET)
 	install -Dm755 $(TARGET) $(DESTDIR)$(BINDIR)/$(TARGET)
@@ -26,6 +32,6 @@ uninstall:
 	$(RM) -r $(DESTDIR)$(MAPDIR)
 
 clean:
-	$(RM) $(wildcard src/*.o) $(TARGET)
+	$(RM) $(wildcard src/*.o) $(wildcard src/*.d) $(TARGET)
 
 .PHONY: install uninstall clean


### PR DESCRIPTION
This PR fixes an issue in the Makefile. Specifically, previously, any modifications of files like src/globals.h would not trigger a rebuild of src/globals.o. The PR fixes this by including them as additional dependencies.

